### PR TITLE
ConfigWizard & remove stratified EWAS for-loop

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,62 +1,55 @@
-import pandas as pd
-from helper_fxns import generate_observed_combinations
+from helper_fxns import ConfigWizard
+
 configfile: "config.yml"
+CW = ConfigWizard(config)
+
 
 #----SET VARIABLES----#
-## EWAS VARIABLES
-PHENO = config["pheno"]
-MVALS = config["mvals"]
-ASSOC = config["association_variable"]
-STRATIFIED = config["stratified_ewas"]
-STRAT_VARS = config["stratify_variables"]
-CHUNK_SIZE = config["chunk_size"]
-PROCESSING_TYPE = config["processing_type"]
-N_WORKERS = config["workers"]
-OUT_DIR = config["out_directory"]
-OUT_TYPE = config["out_type"]
-PLOTS = ["traces", "posteriors", "fit", "qqs"]
+PHENO = str(CW.pheno)
+MVALS = str(CW.mvals)
+ASSOC = CW.assoc_var
+STRATIFIED = CW.stratified
+STRAT_VARS = CW.strat_vars
+CHUNK_SIZE = CW.chunk_size
+PROCESSING_TYPE = CW.processing_type
+N_WORKERS = CW.n_workers
+OUT_DIR = str(CW.out_dir)
+OUT_TYPE = CW.out_type
 
-# DMR VARIABLES
-DMR = config["dmr_analysis"]
-ANNO = config["genome_build"]
-MIN_P = config["min_pvalue"]
-WIN_SZ = config["window_size"]
-REGION_FILTER = config["region_filter"]
+# Plots / groups
+PLOTS = CW.bacon_plot_kinds
+GROUPS = CW.groups  # e.g., ["female"] or ["female","male","..."] or ["all"]
 
-# Stratified EWAS
-GROUPS = generate_observed_combinations(df=pd.read_csv(config["pheno"]), stratify_cols=config["stratify_variables"])
+# Unstratified outputs
+raw_results      = str(CW.raw_results)
+bacon_results    = str(CW.bacon_results)
+bacon_plots      = CW.bacon_plot_files()
 
-#---- INPUT & OUTPUT FILES ----#
-# Final output results, stratified or not
-annotated_results = OUT_DIR + ASSOC + "_ewas_annotated_results" + OUT_TYPE
-manhattan_qq_plot = OUT_DIR + ASSOC + "_ewas_manhattan_qq_plots.jpg"
+# Stratified outputs
+strat_raw_results    = CW.strat_raw_results()
+strat_bacon_results  = CW.strat_bacon_results()
+strat_bacon_plots    = CW.strat_bacon_plot_files()
 
-# Combined (not stratified) EWAS outputs
-raw_results = OUT_DIR + ASSOC + "_ewas_results" + OUT_TYPE
-bacon_results = OUT_DIR + ASSOC + "_ewas_bacon_results" + OUT_TYPE
-bacon_plots = expand(OUT_DIR + "bacon_plots/" + ASSOC + "_{plot}.jpg", plot=PLOTS)
-
-# Stratified EWAS outputs
-strat_raw_results = expand(OUT_DIR + "{group}/{group}_" + ASSOC + "_ewas_results" + OUT_TYPE, group=GROUPS)
-strat_bacon_results = expand(OUT_DIR + "{group}/{group}_" + ASSOC + "_ewas_bacon_results" + OUT_TYPE, group=GROUPS)
-strat_bacon_plots = expand(OUT_DIR + "{group}/bacon_plots/{group}_" + ASSOC + "_{plot}.jpg", group=GROUPS, plot=PLOTS)
-meta_analysis_results = OUT_DIR + ASSOC + "_ewas_meta_analysis_results_1.txt"
+# Final Outputs
+annotated_results = str(CW.annotated_results)
+manhattan_qq_plot = str(CW.manhattan_qq_plot)
+meta_analysis_results = str(CW.meta_analysis_results)
 
 # DMR outputs
-results_bed = OUT_DIR + ASSOC + "_ewas_annotated_results.bed"
-dmr_acf = OUT_DIR + "dmr/" + ASSOC + "_ewas.acf.txt"
-dmr_args = OUT_DIR + "dmr/" + ASSOC + "_ewas.args.txt"
-dmr_fdr = OUT_DIR + "dmr/" + ASSOC + "_ewas.fdr.bed.gz"
-dmr_regions = OUT_DIR + "dmr/" + ASSOC + "_ewas.regions.bed.gz"
-dmr_slk = OUT_DIR + "dmr/" +  ASSOC + "_ewas.slk.bed.gz"
-dmr_anno = OUT_DIR + "dmr/" + ASSOC + "_ewas.anno." + ANNO + ".bed"
-dmr_cpg_anno = OUT_DIR + "dmr/" + ASSOC + "_ewas.anno." + ANNO + ".with_cpgs.bed"
+results_bed = str(CW.dmr_results_bed)
+dmr_acf     = str(CW.dmr_acf)
+dmr_args    = str(CW.dmr_args)
+dmr_fdr     = str(CW.dmr_fdr)
+dmr_regions = str(CW.dmr_regions)
+dmr_slk = str(CW.dmr_slk)
+dmr_anno = str(CW.dmr_anno)
+dmr_cpg_anno = [str(CW.dmr_cpg_anno)]
 
 dmr_infile = [results_bed]
-dmr_outfiles = [dmr_acf, dmr_args, dmr_fdr, dmr_regions, dmr_slk, dmr_anno, dmr_cpg_anno]
+dmr_outfiles = [dmr_acf, dmr_args, dmr_fdr, dmr_regions, dmr_slk, dmr_anno]
 
 #---- DETERMINE INPUT FILES FOR RULE ALL ----#
-if STRATIFIED == "yes":
+if STRATIFIED == True:
     in_files = [PHENO, MVALS, strat_raw_results, strat_bacon_results,
                 strat_bacon_plots, meta_analysis_results,
                 annotated_results, manhattan_qq_plot]
@@ -65,8 +58,8 @@ else:
                 bacon_plots, annotated_results, 
                 manhattan_qq_plot]
 
-if DMR == "yes":
-    in_files = in_files + dmr_infile + dmr_outfiles
+if CW.dmr == True:
+    in_files = in_files + dmr_infile + dmr_outfiles + dmr_cpg_anno
 else:
     in_files = in_files
 

--- a/helper_fxns.py
+++ b/helper_fxns.py
@@ -1,18 +1,204 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, List, Iterable, Optional, Union
+import os
 import pandas as pd
 
-def generate_observed_combinations(df, stratify_cols):
-    if len(stratify_cols) > 0:
-        # Convert integer columns to strings
-        df[stratify_cols] = df[stratify_cols].astype(str)
-        
-        # Group the DataFrame by 'stratify_cols' and aggregate the values
-        observed_combinations = df.groupby(stratify_cols).size().reset_index()
-        
-        # Join the values of each combination with "_"
-        observed_combinations['combination'] = observed_combinations[stratify_cols].apply('_'.join, axis=1)
-        
-        return observed_combinations['combination'].tolist()
+def _to_bool(x: Union[str, bool]) -> bool:
+    if isinstance(x, bool):
+        return x
+    if isinstance(x, str):
+        return x.strip().lower() in {"y", "yes", "true", "1"}
+    return bool(x)
+
+def _norm_path(p: Union[str, Path]) -> Path:
+    # Expand env vars and ~, then resolve relative paths against CWD
+    if isinstance(p, Path):
+        s = str(p)
     else:
-        # If no stratify_cols provided, return a list with only "all"
-        return ['all']
+        s = p
+    s = os.path.expandvars(os.path.expanduser(s))
+    return Path(s)
+
+class ConfigWizard(object):
+    __slots__ = (
+        "config", "mvals", "pheno", "assoc_var", "stratified", "strat_vars",
+        "dmr", "genome_build", "min_pval", "win_size", "region_filter",
+        "chunk_size", "processing_type", "n_workers", "out_dir", "out_type",
+        "_groups", "_bacon_plot_kinds"
+    )
+
+    def __init__(self, cfg: Dict):
+        self.config = cfg
+
+        # --- Required keys (raise early with a good message if missing) ---
+        required = [
+            "mvals", "pheno", "association_variable", "stratified_ewas",
+            "stratify_variables", "dmr_analysis", "genome_build", "min_pvalue",
+            "window_size", "region_filter", "chunk_size", "processing_type",
+            "workers", "out_directory", "out_type",
+        ]
+        missing = [k for k in required if k not in cfg]
+        if missing:
+            raise KeyError(f"Missing required config keys: {', '.join(missing)}")
+
+        # --- Basic fields ---
+        self.mvals = _norm_path(cfg["mvals"])
+        self.pheno = _norm_path(cfg["pheno"])
+
+        self.assoc_var: str = str(cfg["association_variable"])
+        self.stratified: bool = _to_bool(cfg["stratified_ewas"])
+        self.strat_vars: List[str] = list(cfg.get("stratify_variables") or [])
+
+        self.dmr: bool = _to_bool(cfg["dmr_analysis"])
+        self.genome_build: str = str(cfg["genome_build"])
+        self.min_pval: float = float(cfg["min_pvalue"])
+        self.win_size: int = int(cfg["window_size"])
+        self.region_filter: float = float(cfg["region_filter"])
+
+        self.chunk_size: int = int(cfg["chunk_size"])
+        self.processing_type: str = str(cfg["processing_type"])
+        self.n_workers: int = int(cfg["workers"])
+
+        # Ensure the output directory is a Path, and does NOT need a trailing slash
+        self.out_dir: Path = _norm_path(cfg["out_directory"])
+        self.out_type: str = str(cfg["out_type"])  # e.g. ".csv" or ".csv.gz"
+
+        # Keep plot kinds centralized
+        self._bacon_plot_kinds: List[str] = ["traces", "posteriors", "fit", "qqs"]
+
+        # Defer computing groups until requested (but you can force with CW.groups)
+        self._groups: Optional[List[str]] = None
+
+    # ---------- Commonly-used simple properties ----------
+    @property
+    def bacon_plot_kinds(self) -> List[str]:
+        return list(self._bacon_plot_kinds)
+
+    @property
+    def groups(self) -> List[str]:
+        """Observed strat groups from phenotype file. Returns ["all"] if not stratified."""
+        if self._groups is not None:
+            return self._groups
+
+        if not self.stratified or not self.strat_vars:
+            self._groups = ["all"]
+            return self._groups
+
+        # Load phenotype and build observed combos
+        df = pd.read_csv(self.pheno)
+        # Convert everything used for strat to string to avoid 0 vs "0" issues
+        for col in self.strat_vars:
+            if col not in df.columns:
+                raise KeyError(f"Stratify variable '{col}' not found in phenotype file.")
+        df[self.strat_vars] = df[self.strat_vars].astype(str)
+
+        combos = (
+            df.groupby(self.strat_vars)
+              .size()
+              .reset_index()
+        )
+        combos["combination"] = combos[self.strat_vars].agg("_".join, axis=1)
+        observed = combos["combination"].tolist()
+        # Guarantee deterministic sort
+        self._groups = sorted(set(observed))
+        return self._groups
+
+    # ---------- Path helpers ----------
+    def _prefix(self, group: Optional[str] = None) -> str:
+        """
+        "BMI"                       (unstratified)
+        "female_BMI" or "F_1_BMI"  (stratified with observed group name)
+        """
+        if not group or group == "all":
+            return f"{self.assoc_var}"
+        return f"{group}_{self.assoc_var}"
+
+    def _out(self, *parts: Union[str, Path]) -> Path:
+        return self.out_dir.joinpath(*map(lambda p: str(p), parts))
+
+    # ---------- Unstratified outputs ----------
+    @property
+    def raw_results(self) -> Path:
+        return self._out(f"{self._prefix()}_ewas_results{self.out_type}")
+
+    @property
+    def bacon_results(self) -> Path:
+        return self._out(f"{self._prefix()}_ewas_bacon_results{self.out_type}")
+
+    @property
+    def manhattan_qq_plot(self) -> Path:
+        # Keep jpg since that’s what your Snakefile showed
+        return self._out(f"{self._prefix()}_ewas_manhattan_qq_plots.jpg")
+
+    @property
+    def annotated_results(self) -> Path:
+        return self._out(f"{self._prefix()}_ewas_annotated_results{self.out_type}")
+
+    @property
+    def meta_analysis_results(self) -> Path:
+        return self._out(f"{self._prefix()}_ewas_meta_analysis_results_1.txt")
+
+    def bacon_plot_files(self) -> List[str]:
+        # Return strings for Snakemake expand friendliness
+        return [str(self._out("bacon_plots", f"{self._prefix()}_{k}.jpg"))
+                for k in self._bacon_plot_kinds]
+
+    # ---------- Stratified outputs ----------
+    def strat_raw_results(self) -> List[str]:
+        if self.groups == ["all"]:
+            return []
+        return [str(self._out(g, f"{self._prefix(g)}_ewas_results{self.out_type}"))
+                for g in self.groups]
+
+    def strat_bacon_results(self) -> List[str]:
+        if self.groups == ["all"]:
+            return []
+        return [str(self._out(g, f"{self._prefix(g)}_ewas_bacon_results{self.out_type}"))
+                for g in self.groups]
+
+    def strat_bacon_plot_files(self) -> List[str]:
+        if self.groups == ["all"]:
+            return []
+        files = []
+        for g in self.groups:
+            files.extend(
+                str(self._out(g, "bacon_plots", f"{self._prefix(g)}_{k}.jpg"))
+                for k in self._bacon_plot_kinds
+            )
+        return files
+
+    # ---------- DMR outputs (names lifted from your Snakefile snippet) ----------
+    @property
+    def dmr_results_bed(self) -> Path:
+        return self._out(f"{self._prefix()}_ewas_annotated_results.bed")
+
+    @property
+    def dmr_acf(self) -> Path:
+        return self._out("dmr", f"{self._prefix()}_ewas.acf.txt")
+
+    @property
+    def dmr_args(self) -> Path:
+        return self._out("dmr", f"{self._prefix()}_ewas.args.txt")
+
+    @property
+    def dmr_fdr(self) -> Path:
+        # Keep gz suffix per your Snakefile
+        return self._out("dmr", f"{self._prefix()}_ewas.fdr.bed.gz")
+
+    @property
+    def dmr_regions(self) -> Path:
+        return self._out("dmr", f"{self._prefix()}_ewas.regions.bed.gz")
+
+    @property
+    def dmr_slk(self) -> Path:
+        return self._out("dmr", f"{self._prefix()}_ewas.slk.bed.gz")
+
+    @property
+    def dmr_anno(self) -> Path:
+        return self._out("dmr", f"{self._prefix()}_ewas.anno.{self.genome_build}.bed")
+
+    @property
+    def dmr_cpg_anno(self):
+        return self._out("dmr", f"{self._prefix()}_ewas.anno.{self.genome_build}.with_cpgs.bed")
 

--- a/rules/dmr.smk
+++ b/rules/dmr.smk
@@ -23,11 +23,11 @@ rule run_dmr:
     input:
         in_file = results_bed
     params:
-        o_prefix = OUT_DIR +  "dmr/" + ASSOC + "_ewas",
-        min_p = MIN_P,
-        win_sz = WIN_SZ,
-        region_filter = REGION_FILTER,
-        anno = ANNO
+        o_prefix = OUT_DIR +  "/dmr/" + ASSOC + "_ewas",
+        min_p = CW.min_pval,
+        win_sz = CW.win_size,
+        region_filter = CW.region_filter,
+        anno = CW.genome_build
     output: 
         dmr_outfiles
     conda:
@@ -45,7 +45,7 @@ rule run_dmr:
 
 rule annotate_dmr:
     input:
-        ewas_bed = rules.run_dmr.output,
+        ewas_bed = rules.make_bed.output,
         dmr_bed = dmr_anno
     output:
         dmr_cpg_anno

--- a/rules/stratified_ewas.smk
+++ b/rules/stratified_ewas.smk
@@ -4,12 +4,12 @@ rule stratify_data:
         pheno_file = PHENO,
         methyl_file = MVALS
     params:
-        strat_vars = ' '.join(STRAT_VARS),
+        strat_vars = ','.join(STRAT_VARS),
         o_dir = OUT_DIR,
         n_threads = N_WORKERS
     output: 
-        temp(expand(OUT_DIR + "{group}/{group}_pheno.fst", group = GROUPS)),
-        temp(expand(OUT_DIR + "{group}/{group}_mvals.fst", group = GROUPS))
+        temp(expand(OUT_DIR + "/{group}/{group}_pheno.fst", group = GROUPS)),
+        temp(expand(OUT_DIR + "/{group}/{group}_mvals.fst", group = GROUPS))
     conda:
         "../envs/ewas.yaml"    
     shell:
@@ -22,69 +22,66 @@ rule stratify_data:
         --threads {params.n_threads}
         """
 
-
-for group in GROUPS:
-    rule:
-        name:
-            f"run_ewas_{group}"
-        input:
-            script = "scripts/ewas.R",
-            pheno_file = OUT_DIR + f"{group}/{group}_pheno.fst",
-            methyl_file= OUT_DIR + f"{group}/{group}_mvals.fst"
-        params:
-            assoc_var = ASSOC,
-            stratified = STRATIFIED,
-            cs = config["chunk_size"],
-            pt = config["processing_type"],
-            n_workers = N_WORKERS,
-            o_dir = OUT_DIR + f"{group}/",
-            o_type = OUT_TYPE,
-            o_prefix = f"{group}"
-        output: 
-            OUT_DIR + f"{group}/{group}_" + ASSOC + "_ewas_results" + OUT_TYPE
-        log:
-            f"log/{group}_ewas.log"
-        conda:
-            "../envs/ewas.yaml"
-        shell:
-            """
-            export R_PROGRESSR_ENABLE=TRUE 
-            Rscript {input.script} \
-            --pheno {input.pheno_file} \
-            --methyl {input.methyl_file} \
-            --assoc {params.assoc_var} \
-            --stratified {params.stratified} \
-            --chunk-size {params.cs} \
-            --processing-type {params.pt} \
-            --workers {params.n_workers} \
-            --out-dir {params.o_dir} \
-            --out-type {params.o_type} \
-            --out-prefix {params.o_prefix} \
-            > {log} 2>&1
-            """
-    rule:
-        name:
-            f"run_bacon_{group}"
-        input:
-            in_file = OUT_DIR + f"{group}/{group}_" + ASSOC + "_ewas_results" + OUT_TYPE,
-            script = "scripts/run_bacon.R"
-        params:
-            o_dir = OUT_DIR + f"{group}/",
-            o_type = OUT_TYPE,
-            o_prefix = f"{group}"
-        output: 
-            OUT_DIR + f"{group}/{group}_" + ASSOC + "_ewas_bacon_results" + OUT_TYPE,
-            expand(OUT_DIR + f"{group}/bacon_plots/{group}_" + ASSOC + "_{plot}.jpg", plot = PLOTS)
-        conda:
-            "../envs/ewas.yaml"
-        shell:
-            """
-            Rscript {input.script} \
-            --input-file {input.in_file} \
-            --out-dir {params.o_dir} \
-            --out-prefix {params.o_prefix} \
-            --out-type {params.o_type} \
-            """
+rule run_ewas_group:
+    input:
+        script = "scripts/ewas.R",
+        pheno_file = OUT_DIR + "/{group}/{group}_pheno.fst",
+        methyl_file= OUT_DIR + "/{group}/{group}_mvals.fst"
+    params:
+        assoc_var = ASSOC,
+        stratified = STRATIFIED,
+        cs = config["chunk_size"],
+        pt = config["processing_type"],
+        n_workers = N_WORKERS,
+        o_dir = OUT_DIR + "/{group}/",
+        o_type = OUT_TYPE,
+        o_prefix = "{group}"
+    output:
+        OUT_DIR + "/{group}/{group}_" + ASSOC + "_ewas_results" + OUT_TYPE
+    log:
+        "log/{group}_ewas.log"
+    conda:
+        "../envs/ewas.yaml"
+    shell:
+        """
+        export R_PROGRESSR_ENABLE=TRUE 
+        Rscript {input.script} \
+        --pheno {input.pheno_file} \
+        --methyl {input.methyl_file} \
+        --assoc {params.assoc_var} \
+        --stratified {params.stratified} \
+        --chunk-size {params.cs} \
+        --processing-type {params.pt} \
+        --workers {params.n_workers} \
+        --out-dir {params.o_dir} \
+        --out-type {params.o_type} \
+        --out-prefix {params.o_prefix} \
+        > {log} 2>&1
+        """
+rule run_bacon_group:
+    input:
+        in_file = OUT_DIR + "/{group}/{group}_" + ASSOC + "_ewas_results" + OUT_TYPE,
+        script = "scripts/run_bacon.R"
+    params:
+        o_dir = OUT_DIR + "/{group}/",
+        o_type = OUT_TYPE,
+        o_prefix = "{group}"
+    output:
+        bacon_results = OUT_DIR + "/{group}/{group}_" + ASSOC + "_ewas_bacon_results" + OUT_TYPE,
+        plot_trace= OUT_DIR + "/{group}/bacon_plots/{group}_" + ASSOC + "_traces.jpg",
+        plot_post= OUT_DIR + "/{group}/bacon_plots/{group}_" + ASSOC + "_posteriors.jpg",
+        plot_fit= OUT_DIR + "/{group}/bacon_plots/{group}_" + ASSOC + "_fit.jpg",
+        plot_qqs= OUT_DIR + "/{group}/bacon_plots/{group}_" + ASSOC + "_qqs.jpg"
+    conda:
+        "../envs/ewas.yaml"
+    shell:
+        """
+        Rscript {input.script} \
+        --input-file {input.in_file} \
+        --out-dir {params.o_dir} \
+        --out-prefix {params.o_prefix} \
+        --out-type {params.o_type} \
+        """
 
 rule install_metal:
     output:
@@ -118,9 +115,9 @@ rule install_metal:
 rule make_metal_script:
     input:
         script = "scripts/metal_cmd.sh",
-        in_files = expand(OUT_DIR + "{group}/{group}_" + ASSOC + "_ewas_bacon_results" + OUT_TYPE, group=GROUPS)
+        in_files = expand(OUT_DIR + "/{group}/{group}_" + ASSOC + "_ewas_bacon_results" + OUT_TYPE, group=GROUPS)
     params:
-        out_prefix = OUT_DIR + ASSOC + "_ewas_meta_analysis_results_"
+        out_prefix = OUT_DIR + "/" + ASSOC + "_ewas_meta_analysis_results_"
     output:
         "scripts/meta_analysis_script.sh"
     shell:
@@ -130,6 +127,7 @@ rule make_metal_script:
 rule run_metal:
     input:
         metal = rules.install_metal.output.metal_bin,
+        bacon_group_results = expand(rules.run_bacon_group.output.bacon_results, group = GROUPS),
         script = "scripts/meta_analysis_script.sh"
     output:
         meta_analysis_results

--- a/scripts/annotation.R
+++ b/scripts/annotation.R
@@ -14,7 +14,7 @@ parser$add_argument('--out-dir',
                     required=TRUE,
                     help="Path to output directory")
 parser$add_argument('--stratified',
-                    choices=c("yes", "no"), 
+                    choices=c("yes", "no", "True", "False"),
                     default="no",
                     help="Results from a stratified analysis: yes or no")
 parser$add_argument("--assoc", 
@@ -62,7 +62,7 @@ annotation <- left_join(hg38, cpg.to.rs, by = "cpgid") %>%
               left_join(eqtm, by = "cpgid")
 rm(hg38, cpg.to.rs)
 
-if(stratified=="no"){
+if(stratified=="no" | stratified == "False"){
     ewas <- left_join(ewas, annotation, by = "cpgid")
     ewas <- ewas[order(ewas$bacon.pval),]
 } else{
@@ -71,5 +71,5 @@ if(stratified=="no"){
         ewas$"P-value" <- as.numeric(ewas$"P-value")
         ewas <- ewas[order(ewas$"P-value"),]
 }
-file_name <- paste0(out_dir, assoc, "_ewas_annotated_results", out_type)
+file_name <- paste0(out_dir,"/", assoc, "_ewas_annotated_results", out_type)
 fwrite(ewas, file = file_name)

--- a/scripts/dmr_annotation.R
+++ b/scripts/dmr_annotation.R
@@ -8,7 +8,7 @@ if (length(args) < 2) {
 dmr_file  <- args[1]
 cpg_file  <- args[2]
 out_file  <- sub("(\\.bed)?$", ".with_cpgs.bed", dmr_file)
-
+print(out_file)
 
 # Read DMR annotation bed file output from comb-p
 dmr <- fread(dmr_file, sep = "\t", header = TRUE)

--- a/scripts/ewas.R
+++ b/scripts/ewas.R
@@ -41,7 +41,7 @@ parser$add_argument("--assoc",
                     nargs=1, 
                     help="Variable to perform association with.")
 parser$add_argument('--stratified',
-                    choices=c("yes", "no"), 
+                    choices=c("yes", "no", "True", "False"),
                     default="no",
                     help="Stratified analysis: yes or no")
 parser$add_argument("--chunk-size", 
@@ -201,10 +201,10 @@ results <- ewas(mvals, pheno)
 
 # Export results 
 results$n <- nrow(pheno)
-if (stratified == "yes"){
-    filename <- paste0(out_dir, out_prefix, "_", assoc_var, "_ewas_results", out_type)
+if (stratified == "yes" | stratified == "True"){
+    filename <- paste0(out_dir,"/", out_prefix, "_", assoc_var, "_ewas_results", out_type)
 } else{
-    filename <- paste0(out_dir, assoc_var, "_ewas_results", out_type)
+    filename <- paste0(out_dir,"/", assoc_var, "_ewas_results", out_type)
 }
 
 fwrite(results, file = filename)

--- a/scripts/make_bed.R
+++ b/scripts/make_bed.R
@@ -21,7 +21,7 @@ parser$add_argument('--out-dir',
                     default="~/",  
                     help="Path to output directory")     
 parser$add_argument('--stratified',
-                    choices=c("yes", "no"), 
+                    choices=c("yes", "no", "True", "False"),
                     default="no",
                     help="Results from a stratified analysis: yes or no")
 parser$add_argument("--assoc", 
@@ -42,7 +42,7 @@ assoc <- args$assoc
 res <- fread(results)
 
 # Wrangle results into BED format (chr, start, end, pvalue)
-if(stratified=="no"){
+if(stratified=="no" | stratified == "False"){
     res <- res  %>% 
             dplyr::select(CpG_chrm,CpG_beg,CpG_end, bacon.pval, cpgid) %>%
             arrange(CpG_chrm, CpG_beg)  %>% 
@@ -62,6 +62,6 @@ if(stratified=="no"){
 }
 
 # Export BED file
-file_name <- paste0(out_dir, assoc, "_ewas_annotated_results.bed")
+file_name <- paste0(out_dir, "/", assoc, "_ewas_annotated_results.bed")
 write.table(res, file = file_name, append = FALSE, sep = "\t",
              row.names = FALSE, col.names = TRUE, quote = FALSE)

--- a/scripts/plots.R
+++ b/scripts/plots.R
@@ -16,7 +16,7 @@ parser$add_argument('--out-dir',
                     required=TRUE,
                     help="Path to output directory")
 parser$add_argument('--stratified',
-                    choices=c("yes", "no"), 
+                    choices=c("yes", "no", "True", "False"),
                     default="no",
                     help="Results from a stratified analysis: yes or no")
 parser$add_argument("--assoc", 
@@ -37,7 +37,7 @@ assoc <- args$assoc
 ewas <- fread(results)
 
 # Wrangle data for plotting
-if (stratified == "yes"){
+if (stratified == "yes" | stratified == "True"){
   ewas <- ewas %>% 
     dplyr::select(MarkerName, CpG_chrm, CpG_beg, "P-value") %>% 
     rename("Pvalue" = "P-value") %>% 
@@ -140,7 +140,7 @@ left.panel <- plot_grid(NULL, qq.plot, labels= c("B", ""), label_size = 22,
 full.plot <- plot_grid(manh.plot, left.panel, labels = c("A", ""), ncol = 2,
           rel_widths = c(2.5,1), label_size = 22)
 
-filename <- paste0(out_dir, assoc, "_ewas_manhattan_qq_plots.jpg")
+filename <- paste0(out_dir, "/", assoc, "_ewas_manhattan_qq_plots.jpg")
 ggsave(filename,
       plot = full.plot,
       width = 32,

--- a/scripts/run_bacon.R
+++ b/scripts/run_bacon.R
@@ -93,21 +93,21 @@ ewas$lambda <- QCEWAS::P_lambda(ewas$p.value)
 ewas$b.lambda <- QCEWAS::P_lambda(ewas$bacon.pval)
 
 # Export bacon-adjusted results
-fwrite(ewas, file=paste0(out_dir, filename, "_ewas_bacon_results", out_type))
+fwrite(ewas, file=paste0(out_dir, "/", filename, "_ewas_bacon_results", out_type))
 
 # Run performance tests and export plots
 traces_plot <- ggtraces(bc) #+ labs(title = paste0(plotname, " traces"))
-ggsave(paste0(out_dir, "bacon_plots/", filename, "_traces.jpg"),
+ggsave(paste0(out_dir, "/bacon_plots/", filename, "_traces.jpg"),
        plot = traces_plot,
        width = 16, height = 9.8, units = "cm")
 
 posteriors_plot <- ggposteriors(bc) #+ labs(title = paste0(plotname, " posteriors"))
-ggsave(paste0(out_dir, "bacon_plots/", filename, "_posteriors.jpg"),
+ggsave(paste0(out_dir, "/bacon_plots/", filename, "_posteriors.jpg"),
        plot = posteriors_plot,
        width = 10.5, height = 9.8, units = "cm")
 
 fit_plot <- ggfit(bc) #+ labs(title = paste0(plotname, " fit"))
-ggsave(paste0(out_dir, "bacon_plots/", filename, "_fit.jpg"),
+ggsave(paste0(out_dir, "/bacon_plots/", filename, "_fit.jpg"),
        plot = fit_plot,
        width = 12, height = 9.8, units = "cm")
 
@@ -115,7 +115,7 @@ qq_plot <- bacon::plot(bc, type = c("qq")) +
        labs(title = paste0(plotname, " qq plots")) +
        theme_bw(base_size = 12) +
        theme(legend.position = "none")
-ggsave(paste0(out_dir, "bacon_plots/", filename, "_qqs.jpg"),
+ggsave(paste0(out_dir, "/bacon_plots/", filename, "_qqs.jpg"),
        plot = qq_plot,
        width = 12, height = 9.8, units = "cm")
 

--- a/scripts/stratify.R
+++ b/scripts/stratify.R
@@ -97,13 +97,13 @@ for (i in names(subset.key)){
   p.sub <- pheno[[i]]
   p.sub <- p.sub %>%
     rownames_to_column(var="SampleID") # Move the sample IDs to the rownames
-  filename <- paste0(out_dir, i, "/", i, "_pheno.fst")
+  filename <- paste0(out_dir,"/", i, "/", i, "_pheno.fst")
   write_fst(p.sub, path = filename)
 }
 for (i in names(subset.key)){
   m.sub <- mvals[[i]]
   m.sub <- m.sub %>%
     rownames_to_column(var="SampleID")
-  filename <- paste0(out_dir, i, "/", i, "_mvals.fst")
+  filename <- paste0(out_dir,"/", i, "/", i, "_mvals.fst")
   write_fst(m.sub, path = filename) 
 }


### PR DESCRIPTION
Add a python class, ConfigWizard, to help parse the config and create consistent filepath names. Updated Snakefile, scripts, and other rules minimally to function with the new config manager. Removed the for-loop for the stratified EWAS rules to use wildcards instead.